### PR TITLE
query only news flagged with featured on the indexpage

### DIFF
--- a/src/pages/IndexPage/IndexPage.js
+++ b/src/pages/IndexPage/IndexPage.js
@@ -6,7 +6,7 @@ import FeaturedReviews from 'components/FeaturedReviews';
 import Loader from 'layout/Loader';
 
 const GET_REVIEWS_AND_NEWS = gql`
-  query ReviewsAndNews {
+  query HomeReviewsAndNews {
     albumReviewCollection(limit: 5) {
       items {
         cover {
@@ -27,7 +27,7 @@ const GET_REVIEWS_AND_NEWS = gql`
         }
       }
     }
-    newsCollection(limit: 3) {
+    newsCollection(where: { featured: true }, limit: 3) {
       items {
         headline
         image {


### PR DESCRIPTION
I've added a Boolean type to our news data model in contentful, that if true(yes) will then be displayed on our home page. 
I simply passed a `where` argument to our `newsCollection` query that checks for that. 

We can later decide if we want this to be in a "tags and/or category" option instead of a Boolean. It would only make sense if we are planning to use tags and categories.